### PR TITLE
adicionando human interface guidelines de iOS e Android

### DIFF
--- a/apps/praticas & metodo/readme.md
+++ b/apps/praticas & metodo/readme.md
@@ -41,7 +41,10 @@
 [em construção]
 
 ## interface humana
-[em construção]
+| tags 	| título    	| autor(a/es) e local |
+|-----------	|-----------	|-----------	|
+| `A`‧:desktop_computer:‧:uk:‧:apple: | [iOS Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios) | Apple |
+| `A`‧:desktop_computer:‧:uk:‧:robot: | [Android Human Interface Guidelines](https://developer.android.com/guide/topics/ui) | Google |
 
 ## automação
 [em construção]


### PR DESCRIPTION
adicionando link para os textos oficiais que serve de guia para construção de interface, tanto iOS quanto android.

## interface humana
 [em construção]
 | tags 	| título    	| autor(a/es) e local |
 |-----------	|-----------	|-----------	|
 | `A`‧:desktop_computer:‧:uk:‧:apple: | [iOS Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios) | Apple |
 | `A`‧:desktop_computer:‧:uk:‧:robot: | [Android Human Interface Guidelines](https://developer.android.com/guide/topics/ui) | Google |