### PR TITLE
fix enjuca domain name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## carreira enjoei
 
-uma lista selecionada de conteúdos sobre tecnologia, pra te ajudar na jornada do [enjuCa](https://enjuca.enjoei.com.br), o plano de carreira do enjoei!
+uma lista selecionada de conteúdos sobre tecnologia, pra te ajudar na jornada do [enjuCa](https://carreira.enjoei.com), o plano de carreira do enjoei!
 
 
 ## equipes


### PR DESCRIPTION
Fix enjuca domain to `https://carreira.enjoei.com/`